### PR TITLE
Add optional post-job command support and curl for heartbeat monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,8 @@ RUN \
         adwaita-icon-theme \
         supercronic \
         pcmanfm \
-        firefox-esr
+        firefox-esr \
+        curl
 
 # Generate and install favicons.
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,7 @@ RUN \
         adwaita-icon-theme \
         supercronic \
         pcmanfm \
-        firefox-esr \
-        curl
+        firefox-esr
 
 # Generate and install favicons.
 RUN \

--- a/README.md
+++ b/README.md
@@ -669,6 +669,8 @@ environment variables:
   name of the saved FreeFileSync synchronization configuration.
 - `FFS_SCHEDULED_BATCH_JOB_<ID>_CRON`: Cron expression of the schedule.  See
   https://crontab.guru to create a valid Cron expression.
+- `FFS_SCHEDULED_BATCH_JOB_<ID>_CMD` *(optional)*: An additional shell command
+  to run after the FreeFileSync job completes successfully.
 
 Where `<ID>` is a numerical identifier of your choice.
 

--- a/rootfs/etc/cont-init.d/55-freefilesync.sh
+++ b/rootfs/etc/cont-init.d/55-freefilesync.sh
@@ -38,6 +38,7 @@ for ID in $(env | sed -nr 's/FFS_SCHEDULED_BATCH_JOB_([0-9]+)_NAME=.*/\1/p')
 do
     eval "JOB_NAME=\"\${FFS_SCHEDULED_BATCH_JOB_${ID}_NAME:-}\""
     eval "JOB_CRON=\"\${FFS_SCHEDULED_BATCH_JOB_${ID}_CRON:-}\""
+    eval "JOB_CMD=\"\${FFS_SCHEDULED_BATCH_JOB_${ID}_CMD:-}\""
 
     if [ -z "$JOB_NAME" ]; then
         echo "ERROR: FFS_SCHEDULED_BATCH_JOB_${ID}_NAME environment variable has no value."
@@ -60,5 +61,9 @@ do
         fi
     fi
 
-    echo "$JOB_CRON /opt/FreeFileSync/Bin/FreeFileSync /config/$JOB_NAME.ffs_batch" >> /tmp/ffs_batch_jobs.cron
+    if [ -n "$JOB_CMD" ]; then
+        echo "$JOB_CRON /opt/FreeFileSync/Bin/FreeFileSync /config/$JOB_NAME.ffs_batch && $JOB_CMD" >> /tmp/ffs_batch_jobs.cron
+    else
+        echo "$JOB_CRON /opt/FreeFileSync/Bin/FreeFileSync /config/$JOB_NAME.ffs_batch" >> /tmp/ffs_batch_jobs.cron
+    fi
 done


### PR DESCRIPTION
This PR introduces two changes to the FreeFileSync Docker container:

1. **New environment variable**

   * `FFS_SCHEDULED_BATCH_JOB_<ID>_CMD` (optional)
   * Allows specifying an additional shell command to run **after** a FreeFileSync batch job completes successfully.
   * This makes it possible to easily integrate with heartbeat monitoring services (e.g. [louislam/uptime-kuma](https://github.com/louislam/uptime-kuma)) by running a simple `curl` request after each job to confirm it ran as expected.

2. **Added `curl` to installed tools**

   * Installed `curl` in the container image so it can be used for the above example without requiring a custom image.
   * Example usage with `FFS_SCHEDULED_BATCH_JOB_<ID>_CMD` for a heartbeat monitor:

     ```bash
     FFS_SCHEDULED_BATCH_JOB_1_CMD="curl -fsS https://my-uptime-kuma-endpoint.example.com/ping/abcdef123456"
     ```

With these changes, users can set up automated backup jobs **and** have them trigger external services or monitoring endpoints for better observability and reliability alerts.